### PR TITLE
Fix build issues by repairing menu preview and adding path alias

### DIFF
--- a/src/components/MenuEditor.tsx
+++ b/src/components/MenuEditor.tsx
@@ -47,7 +47,15 @@ export default function MenuEditor() {
     if (!msg) {
       // opção inválida
       const linhas = data.opcoes.map(o => `${o.ordem} – ${cleanLabel(o.texto)}`)
-      return ['*Opção inválida. Tente novamente.*', '', '*Digite a opção desejada:*', *linhas, '', 'Para voltar a este menu, digite:', '*#menu*'].join('\n')
+      return [
+        '*Opção inválida. Tente novamente.*',
+        '',
+        '*Digite a opção desejada:*',
+        ...linhas,
+        '',
+        'Para voltar a este menu, digite:',
+        '*#menu*'
+      ].join('\n')
     }
     return msg
   }, [previewEntrada, data.opcoes, previewMenu])

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
   server: {
     port: 5173
   }


### PR DESCRIPTION
## Summary
- fix menu preview string assembly to avoid TypeScript errors
- configure `@` alias resolution in Vite

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c47f07388333b739c029a36bbff9